### PR TITLE
Made system binaries (ls, readlink, etc.) discovery more generalized.

### DIFF
--- a/perlswitcher.bashrc
+++ b/perlswitcher.bashrc
@@ -1,10 +1,10 @@
 # Perlswitcher
 # Switch between system perl + local::lib and user perl
 
-LS=/bin/ls
 WHICH=/usr/bin/which
-READLINK=/bin/readlink
-SYSTEM_PERL=/usr/bin/perl
+LS=$($WHICH ls)
+READLINK=$($WHICH readlink)
+SYSTEM_PERL=$($WHICH perl)
 
 : <<=cut
 =pod


### PR DESCRIPTION
READLINK, LS, SYSTEM_PERL are now set via call to 'which' (which is set manually).
